### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ Module.symvers
 Mkfile.old
 dkms.conf
 /.project
+
+main.asm

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A football management game written in C and Z80 assembly for the Sinclair ZX80 w
 	Testing:	Moggy, Graz R
 	Tech support:	Andy Rea, Dr Beep
 	
-	(c) Donkeysoft MMXVII
-
+	(c) Donkeysoft MMXVII - published on real media by Monument Microgames
+	http://www.monumentmicrogames.com/
+	
+	Look out for more exciting Donkeysoft productions for your Sinclair home computer
 --

--- a/main.c
+++ b/main.c
@@ -140,7 +140,7 @@ unsigned char startGame()
 {
 	unsigned char yn[2];
 	unsigned char _manager[16];
-	prompt("please enter your name\n(max 16 characters, no spaces)", 8);
+	prompt("please enter your name\n(max 16 characters)", 8);
 	_manager[0] = CLEAR;
 	gets(_manager);
 	if(!_manager[0])

--- a/main.c
+++ b/main.c
@@ -69,6 +69,7 @@
 #define INVERSE(A)	(0x80 | A)
 #define NL			0x76
 #define EOF			0xff
+#define DFILE		$400c
 
 /**
  * Function prototypes
@@ -266,21 +267,23 @@ unsigned char prompt(unsigned char txt[32], unsigned char lineNumber)
  *
  * @param	na
  * @author	sbebbington
- * @date	21 Aug 2017
- * @version	1.1
+ * @date	22 Aug 2017
+ * @version	1.1a
+ * @todo	Should be able to increase just the L
+ * 			register of the DFILE
  */
 unsigned char cls()
 {
 	__asm
 	exx
-	ld hl,($400c)
+	ld hl,(_DFILE)
 	ld bc,$0300
 	ld d,$21
-	inc hl
+	inc l
 	CLS:
 		dec d
 		jr z,NEWLINE
-		ld (hl),$00
+		ld (hl),_CLEAR
 	DECC:
 		inc hl
 		dec c
@@ -291,7 +294,7 @@ unsigned char cls()
 		jr z,EXIT
 		jr CLS
 	NEWLINE:
-		ld (hl),$76
+		ld (hl),_NL
 		ld d,$21
 		jr DECC
 	EXIT:
@@ -308,16 +311,16 @@ unsigned char cls()
  *
  * @param	unsigned char, unsigned char
  * @author	sbebbington
- * @date	21 Aug 2017
- * @version	1.2a
+ * @date	22 Aug 2017
+ * @version	1.2b
  */
 unsigned char printAt(unsigned short xy) __z88dk_fastcall
 {
 	__asm
 	ld b,h
 	ld c,l
-	ld hl,($400c)
-	inc hl
+	ld hl,(_DFILE)
+	inc l
 	add hl,bc
 	ld bc,_text
 	CHAROUT:

--- a/zx80s.h
+++ b/zx80s.h
@@ -4,7 +4,7 @@
  * @author:     Shaun B
  * @version:    1.0.4 - 2017-08-21
  *
- **/
+ */
 
 /// Pre-processor symbols:
 #define CLEAR		0x00


### PR DESCRIPTION
Some minor refactoring to save a few bytes and to test some theories.

It seems that unlike old z88dk, one is still unable to use pre-processor symbols in the assembly bits but no issues.